### PR TITLE
Fix upstream issue with OmniAuth OAuth2 Gem

### DIFF
--- a/lib/omniauth/strategies/asana.rb
+++ b/lib/omniauth/strategies/asana.rb
@@ -37,6 +37,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.params['data']
       end
+      
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
     end
   end
 end


### PR DESCRIPTION
OmniAuth had removed the callback_url method to better fit the OAuth specs. In turn, it may break some downstream gems and result in errors regarding the redirect_uri:

`OAuth2::Error, invalid_grant: The`redirect_uri`provided did not match what is authorized by the code`

Putting this method into the Asana stratagy fixes this error.
