### PR TITLE
Require omniauth > 2

### DIFF
--- a/omniauth-asana.gemspec
+++ b/omniauth-asana.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 2.0.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1'
 end


### PR DESCRIPTION
This PR merely updates omniauth to version 2 due to security issues

Reference: https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284